### PR TITLE
remove right margin on search input

### DIFF
--- a/scss/components/_uthsc-site-nav.scss
+++ b/scss/components/_uthsc-site-nav.scss
@@ -56,7 +56,6 @@ $uthsc-site-nav-input-width: 160px !default;
 
   input {
     width: $uthsc-site-nav-input-width;
-    margin-#{$global-right}: 1rem;
   }
 
   input.button {


### PR DESCRIPTION
this is unused and there's currently an inline style to un-do it on the input field in ouc